### PR TITLE
feat: Tag docker image with major.minor version

### DIFF
--- a/.github/workflows/ghcr_publish.yml
+++ b/.github/workflows/ghcr_publish.yml
@@ -33,8 +33,8 @@ jobs:
                 echo $RELEASE_VERSION
                 echo ${{ env.RELEASE_VERSION }}
             - name: Build and publish lock manager image with ver and latest tag
-              run: sh bin/ghcr-publish.sh lock-manager $RELEASE_VERSION
+              run: bash bin/ghcr-publish.sh lock-manager $RELEASE_VERSION "y"
 
-             
 
-   
+
+

--- a/bin/ghcr-publish.sh
+++ b/bin/ghcr-publish.sh
@@ -1,13 +1,112 @@
 #!/bin/bash
 
 set -e
+
 package_name=$1
 version=$2
+make_additional_tag=$3
 
+if [ "${make_additional_tag}" == "" ];
+then
+  make_additional_tag="n"
+fi
+
+is_number() {
+  value="${1}"
+  re='^[0-9]+$'
+  if ! [[ "$value" =~ $re ]];
+  then
+    echo "0"
+  else
+    echo "1"
+  fi
+}
+
+push_tag() {
+  echo "all args = $@"
+  package_name=$1
+  version=$2
+  tag=$3
+
+  tag_with_version=$package_name:$version
+  echo "tag_with_version=${tag_with_version}"
+
+  tag_ref=ghcr.io/kindredgroup/pit-toolkit/$tag_with_version
+  echo "tag_ref=${tag_ref}"
+  echo ""
+
+  pwd
+  echo ""
+  ls -lah
+  echo ""
+
+  if [ "${tag}" == "" ];
+  then
+    echo "docker build --tag $tag_ref ."
+    docker build --tag "${tag_ref}" .
+    echo "docker push ${tag_ref}"
+    docker push "${tag_ref}"
+    echo ""
+  else
+    new_tag_ref=ghcr.io/kindredgroup/pit-toolkit/$tag
+    echo "docker tag ${tag_ref} ${new_tag_ref}"
+    docker tag "${tag_ref}" "${new_tag_ref}"
+
+    echo "docker push ${new_tag_ref}"
+    docker push "${new_tag_ref}"
+    echo ""
+  fi
+}
+
+home=$(pwd)
+echo "cd $package_name"
 cd $package_name
-tag_with_version=$package_name:$version
-tag_ref=ghcr.io/kindredgroup/pit-toolkit/$tag_with_version
-echo $tag_ref
-docker build . --tag $tag_ref
-#for ghcr.io access token mentioned in the github secrets and accessed in actions
-docker push $tag_ref
+push_tag "${package_name}" "${version}"
+
+if [ "${make_additional_tag}" == "n" ];
+then
+  exit 0
+fi
+
+IFS="." && read -a array <<< "$version"
+segments_in_version=$(echo "${#array[@]}")
+echo "The number of segments in version is ${segments_in_version}..."
+if [ $segments_in_version -lt 3 ]; then
+  echo "There is no need to compute major and minor version as the number of segments is just: ${segments_in_version}"
+  exit
+fi
+
+# check if any of the segments have words, if so, DO NOT produce additional tag.
+make_additional_tag="y"
+
+for i in "${!array[@]}"; do
+  if [ $i -gt 0 ];
+  then
+    is_nr=$(is_number "${array[i]}")
+
+    if [ "${is_nr}" == 1 ]; then
+      echo "the segment '${i}' is a number: ${array[i]}"
+    else
+      echo "the segment '${i}' is NOT a number: ${array[i]}"
+      make_additional_tag="n"
+      break
+    fi
+  fi
+done
+
+if [ "${make_additional_tag}" == "n" ];
+then
+  echo "Image will not be tagged with generic tag."
+  exit
+fi
+
+# Create one more tag for the image
+major_minor_version="${array[0]}.${array[1]}"
+echo "Computed major_minor_version=${major_minor_version}"
+
+push_tag "${package_name}" "${major_minor_version}"
+
+cd $home
+
+git tag -f "${major_minor_version}"
+git push origin tag "${major_minor_version}"

--- a/bin/ghcr-publish.sh
+++ b/bin/ghcr-publish.sh
@@ -26,7 +26,6 @@ push_tag() {
   echo "all args = $@"
   package_name=$1
   version=$2
-  tag=$3
 
   tag_with_version=$package_name:$version
   echo "tag_with_version=${tag_with_version}"
@@ -40,22 +39,11 @@ push_tag() {
   ls -lah
   echo ""
 
-  if [ "${tag}" == "" ];
-  then
-    echo "docker build --tag $tag_ref ."
-    docker build --tag "${tag_ref}" .
-    echo "docker push ${tag_ref}"
-    docker push "${tag_ref}"
-    echo ""
-  else
-    new_tag_ref=ghcr.io/kindredgroup/pit-toolkit/$tag
-    echo "docker tag ${tag_ref} ${new_tag_ref}"
-    docker tag "${tag_ref}" "${new_tag_ref}"
-
-    echo "docker push ${new_tag_ref}"
-    docker push "${new_tag_ref}"
-    echo ""
-  fi
+  echo "docker build --tag $tag_ref ."
+  docker build --tag "${tag_ref}" .
+  echo "docker push ${tag_ref}"
+  docker push "${tag_ref}"
+  echo ""
 }
 
 home=$(pwd)
@@ -104,7 +92,7 @@ fi
 major_minor_version="${array[0]}.${array[1]}"
 echo "Computed major_minor_version=${major_minor_version}"
 
-push_tag "${package_name}" "${version}" "${major_minor_version}"
+push_tag "${package_name}" "${major_minor_version}"
 
 cd $home
 

--- a/bin/ghcr-publish.sh
+++ b/bin/ghcr-publish.sh
@@ -104,7 +104,7 @@ fi
 major_minor_version="${array[0]}.${array[1]}"
 echo "Computed major_minor_version=${major_minor_version}"
 
-push_tag "${package_name}" "${major_minor_version}"
+push_tag "${package_name}" "${version}" "${major_minor_version}"
 
 cd $home
 


### PR DESCRIPTION
This changes github action pipeline by: 
Creating additional a) docker tag; b) git tag.

To make it easier to refer to the specific "latest stable" PIT version, we add additional generic tag made of 1st two segments of original tag. 
A) When we build docker image tagged as v2.0.10 then we will also automagically tag that image with "v2.0", where the new tag will be made from original user tag. 
B) We will also tag repo with new tag "v2.0". If it already exists then the new tag will be moved to the new commit.