### PR TITLE
Feature/support load test app custom port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 node_modules
 tmp*
 .env
+.idea
+.DS_Store

--- a/k8s-deployer/src/bootstrap.ts
+++ b/k8s-deployer/src/bootstrap.ts
@@ -4,6 +4,7 @@ import { Config,
   DEFAULT_NAMESPACE_TIMEOUT,
   DEFAULT_SUB_NAMESPACE_GENERATOR_TYPE,
   DEFAULT_SUB_NAMESPACE_PREFIX,
+  DEFAULT_TEST_RUNNER_APP_PORT,
   DEFAULT_TEST_STATUS_POLL_FREQUENCY,
   DEFAULT_TEST_TIMEOUT,
   SUB_NAMESPACE_GENERATOR_TYPE_COMMITSHA,
@@ -31,6 +32,7 @@ export const PARAM_LOCK_MANAGER_MOCK = "--lock-manager-mock"
 export const PARAM_USE_KUBE_PROXY = "--use-kube-proxy"
 export const PARAM_LOCK_MANAGER_API_RETRIES = "--lock-manager-api-retries"
 export const PARAM_ENABLE_CLEANUPS = "--enable-cleanups"
+export const PARAM_TEST_RUNNER_APP_PORT = "--test-runner-app-port"
 
 const readParams = (): Config => {
   logger.debug("readParams()... \n%s", JSON.stringify(process.argv, null, 2))
@@ -92,6 +94,11 @@ const readParams = (): Config => {
     subNsGeneratorType = DEFAULT_SUB_NAMESPACE_GENERATOR_TYPE
   }
 
+  let testRunnerAppPort = parseInt(params.get(PARAM_TEST_RUNNER_APP_PORT))
+  if(isNaN(testRunnerAppPort)){
+    testRunnerAppPort = DEFAULT_TEST_RUNNER_APP_PORT
+  }
+
   const useKubeProxy = !params.has(PARAM_USE_KUBE_PROXY) ? true : params.get(PARAM_USE_KUBE_PROXY) === "true"
   const enableCleanups = !params.has(PARAM_ENABLE_CLEANUPS) ? true : params.get(PARAM_ENABLE_CLEANUPS) === "true"
 
@@ -118,7 +125,8 @@ const readParams = (): Config => {
     DEFAULT_TEST_STATUS_POLL_FREQUENCY,
     DEFAULT_DEPLOY_CHECK_FREQUENCY,
     DEFAULT_TEST_TIMEOUT,
-    enableCleanups
+    enableCleanups,
+    testRunnerAppPort
   )
 }
 

--- a/k8s-deployer/src/config.ts
+++ b/k8s-deployer/src/config.ts
@@ -7,6 +7,7 @@ export const DEFAULT_SUB_NAMESPACE_GENERATOR_TYPE = SUB_NAMESPACE_GENERATOR_TYPE
 export const DEFAULT_TEST_STATUS_POLL_FREQUENCY = 15_000
 export const DEFAULT_DEPLOY_CHECK_FREQUENCY = 5_000
 export const DEFAULT_TEST_TIMEOUT = 60_000
+export const DEFAULT_TEST_RUNNER_APP_PORT = 80
 
 export class TestReportConfig {
   constructor(
@@ -38,5 +39,6 @@ export class Config {
     readonly deployCheckFrequencyMs: number = DEFAULT_DEPLOY_CHECK_FREQUENCY,
     readonly testTimeoutMs: number = DEFAULT_TEST_TIMEOUT,
     readonly enableCleanups: boolean = true,
+    readonly testRunnerAppPort = DEFAULT_TEST_RUNNER_APP_PORT
   ) {}
 }

--- a/k8s-deployer/src/k8s.ts
+++ b/k8s-deployer/src/k8s.ts
@@ -53,7 +53,7 @@ export class ServiceUrlOptions {
 export const makeServiceUrl = (clusterUrl: string, namespace: Namespace, service: string, testId?: string, options?: ServiceUrlOptions) => {
   if (options?.exposedViaProxy) {
     const url = `${ clusterUrl }/api/v1/namespaces/${ namespace }/services/${ service }`
-    const servicePort = options.servicePort || 8080
+    const servicePort = options.servicePort || 80
     return `${ url }:${ servicePort }/proxy`
   }
 

--- a/k8s-deployer/src/k8s.ts
+++ b/k8s-deployer/src/k8s.ts
@@ -53,7 +53,7 @@ export class ServiceUrlOptions {
 export const makeServiceUrl = (clusterUrl: string, namespace: Namespace, service: string, testId?: string, options?: ServiceUrlOptions) => {
   if (options?.exposedViaProxy) {
     const url = `${ clusterUrl }/api/v1/namespaces/${ namespace }/services/${ service }`
-    const servicePort = options.servicePort || 80
+    const servicePort = options.servicePort || 8080
     return `${ url }:${ servicePort }/proxy`
   }
 

--- a/k8s-deployer/src/test-app-client/test-runner.ts
+++ b/k8s-deployer/src/test-app-client/test-runner.ts
@@ -91,7 +91,7 @@ const runSuite = async (config: Config, spec: DeployedTestSuite): Promise<webapi
       spec.testSuite.id,
       {
         exposedViaProxy: config.servicesAreExposedViaProxy,
-        servicePort: parseInt(config.params.get("--test-app-port"))
+        servicePort: config.testRunnerAppPort
       }
     )
 

--- a/k8s-deployer/src/test-app-client/test-runner.ts
+++ b/k8s-deployer/src/test-app-client/test-runner.ts
@@ -91,7 +91,7 @@ const runSuite = async (config: Config, spec: DeployedTestSuite): Promise<webapi
       spec.testSuite.id,
       {
         exposedViaProxy: config.servicesAreExposedViaProxy,
-        servicePort: parseInt(config.params["--test-app-port"])
+        servicePort: parseInt(config.params.get("--test-app-port"))
       }
     )
 

--- a/k8s-deployer/src/test-app-client/test-runner.ts
+++ b/k8s-deployer/src/test-app-client/test-runner.ts
@@ -90,7 +90,8 @@ const runSuite = async (config: Config, spec: DeployedTestSuite): Promise<webapi
       spec.testSuite.deployment.graph.testApp.id,
       spec.testSuite.id,
       {
-        exposedViaProxy: config.servicesAreExposedViaProxy
+        exposedViaProxy: config.servicesAreExposedViaProxy,
+        servicePort: parseInt(config.params["--test-app-port"])
       }
     )
 

--- a/k8s-deployer/test/test-suite-handler.spec.ts
+++ b/k8s-deployer/test/test-suite-handler.spec.ts
@@ -47,6 +47,7 @@ describe("Deployment happy path", async () => {
     servicesAreExposedViaProxy: false,
     lockManagerApiRetries: 3,
     enableCleanups: true,
+    testRunnerAppPort: 80
   }
 
   const testSuiteNumber = "1"


### PR DESCRIPTION
Add support to configure test runner app port when running the load test. Reasons behind this proposal are 
1. avoid having to start test runner app with root user for port 80
2. providing flexibility for the k8s-deployer consumer to customise the test runner app port