### PR TITLE
fix: missing metadata and allow explicit container log tailing

### DIFF
--- a/k8s-deployer/scripts/tail-container-log.sh
+++ b/k8s-deployer/scripts/tail-container-log.sh
@@ -2,13 +2,17 @@
 
 namespace=$1
 service=$2
-filter=$3
-
-logFile="${namespace}_${service}_pod_${container}.log"
+containerName=$3
+filter=$4
 
 podId=$(kubectl get pods -n $namespace -l "app.kubernetes.io/name=${service}" --field-selector="status.phase=Running" -o jsonpath="{.items[].metadata.name}")
 
 args="-f -n ${namespace} ${podId}"
+
+if [ "${containerName}" != "" ];
+then
+  args="${args} -c ${containerName}"
+fi
 
 if [ "${filter}" != "" ];
 then

--- a/k8s-deployer/src/pod-log-tail.ts
+++ b/k8s-deployer/src/pod-log-tail.ts
@@ -13,7 +13,7 @@ export class PodLogTail {
     readonly logFilePath: string) {
   }
 
-  start(): PodLogTail {
+  start(containerName = ""): PodLogTail {
     if (this.tailer) throw new Error(`Tailer is already attached to process with PID: ${this.tailer.pid}`)
 
     // creating streams
@@ -22,7 +22,7 @@ export class PodLogTail {
 
     this.tailer = NodeShell.spawn(
       "k8s-deployer/scripts/tail-container-log.sh",
-      [ this.namespace, this.service ],
+      [ this.namespace, this.service, containerName ],
       {
         detached: true,
         stdio: [ 'ignore', out, err ]

--- a/k8s-deployer/src/test-app-client/report/schema-v1.ts
+++ b/k8s-deployer/src/test-app-client/report/schema-v1.ts
@@ -49,7 +49,7 @@ export class TestScenario {
     readonly endTime: Date,
     readonly streams: Array<TestStream>,
     readonly components: Array<Component>,
-    metadata?: Object
+    readonly metadata?: Object
   ) {}
 }
 

--- a/k8s-deployer/src/test-app-client/web-api/schema-v1.ts
+++ b/k8s-deployer/src/test-app-client/web-api/schema-v1.ts
@@ -44,7 +44,7 @@ export class ExecutedTestScenario {
     readonly endTime: Date,
     readonly streams: Array<report.TestStream>,
     readonly componentIds: Array<string> = new Array(),
-    readonly metadata?: Object
+    public metadata?: Object
   ) {}
 }
 

--- a/k8s-deployer/src/test-app-client/web-api/schema-v1.ts
+++ b/k8s-deployer/src/test-app-client/web-api/schema-v1.ts
@@ -38,15 +38,13 @@ export class NativeReport {
 }
 
 export class ExecutedTestScenario {
-  metadata: Object = {}
-
   constructor(
     readonly name: string,
     readonly startTime: Date,
     readonly endTime: Date,
     readonly streams: Array<report.TestStream>,
     readonly componentIds: Array<string> = new Array(),
-    metadata?: Object
+    readonly metadata?: Object
   ) {}
 }
 

--- a/k8s-deployer/src/test-suite-handler.ts
+++ b/k8s-deployer/src/test-suite-handler.ts
@@ -274,10 +274,10 @@ export const tailLogs = (suites: Array<DeployedTestSuite>, pitfile: Schema.PitFi
 
   const logTailers = new Array()
 
-  const tailLog = (workspace: string, ns: Namespace, serviceName: string) => {
-    const logFile = `${ workspace }/logs/pod-${ serviceName }-${ ns }.log`
+  const tailLog = (workspace: string, ns: Namespace, serviceName: string, containerName?: string) => {
+    const logFile = `${ workspace }/logs/pod-${ serviceName }-${ ns }${containerName ? "-" + containerName : ""}.log`
     const tailer = new PodLogTail(ns, serviceName, logFile)
-    logTailers.push(tailer.start())
+    logTailers.push(tailer.start(containerName))
   }
 
   for (let suite of suites) {
@@ -285,8 +285,7 @@ export const tailLogs = (suites: Array<DeployedTestSuite>, pitfile: Schema.PitFi
       const shouldTailLog = service.component.logTailing?.enabled === true
       if (!shouldTailLog) continue
 
-      const serviceName = (service.component.logTailing.containerName != undefined) ? service.component.logTailing.containerName : service.component.id
-      tailLog(suite.workspace, suite.namespace, serviceName)
+      tailLog(suite.workspace, suite.namespace, service.component.id, service.component.logTailing.containerName)
     }
 
     if (suite.graphDeployment.testApp.component.logTailing?.enabled) {

--- a/k8s-deployer/test/test-suite-handler.spec.ts
+++ b/k8s-deployer/test/test-suite-handler.spec.ts
@@ -74,7 +74,11 @@ describe("Deployment happy path", async () => {
             name: "comp-1-name",
             id: "comp-1",
             location: { type: LocationType.Local },
-            deploy: { command: "deployment/pit/deploy.sh", statusCheck: { timeoutSeconds: 1, command: "deployment/pit/is-deployment-ready.sh" }}
+            deploy: { command: "deployment/pit/deploy.sh", statusCheck: { timeoutSeconds: 1, command: "deployment/pit/is-deployment-ready.sh" }},
+            logTailing: {
+              enabled: true,
+              containerName: "comp-1-specific-container"
+            }
           }
         ]
       }
@@ -279,11 +283,16 @@ describe("Deployment happy path", async () => {
     ).be.true
 
     // assert that log tailing was invoked
-    chai.expect(nodeShellSpawnStub.callCount).eq(1)
+    chai.expect(nodeShellSpawnStub.callCount).eq(2)
 
     chai.expect(nodeShellSpawnStub.getCall(0).calledWith(
       "k8s-deployer/scripts/tail-container-log.sh",
-      [ namespace, "comp-1-test-app" ]
+      [ namespace, "comp-1", "comp-1-specific-container" ]
+    )).be.true
+
+    chai.expect(nodeShellSpawnStub.getCall(1).calledWith(
+        "k8s-deployer/scripts/tail-container-log.sh",
+        [ namespace, "comp-1-test-app", "" ]
     )).be.true
   })
 


### PR DESCRIPTION
This PR aims to
1. fix the always empty `{}` meta field in the test report
2. allow explicit container log tailing as some services are using a sidecar container to tail logs written a file by the application container to mitigate performance impact on the direct stdout logging in the application container