### PR TITLE
fix: disable tls on elasticsearch connect

### DIFF
--- a/brownie/src/modules/elasticsearch/implementation.ts
+++ b/brownie/src/modules/elasticsearch/implementation.ts
@@ -22,6 +22,9 @@ export const clean = async (moduleName: string, config: Config, moduleConfig: El
   const client = new Client({
     auth: basicAuth,
     nodes: nodes as string[],
+    tls: {
+      rejectUnauthorized: false,
+    },
   })
 
   logger.info("%s.clean(): Connecting to Elasticsearch server...", moduleName)


### PR DESCRIPTION
Turn off tls to fix the error `unable to verify the first certificate`